### PR TITLE
5 remove menus

### DIFF
--- a/config/install/system.menu.footer-second.yml
+++ b/config/install/system.menu.footer-second.yml
@@ -1,7 +1,0 @@
-langcode: en
-status: true
-dependencies: {  }
-id: footer-second
-label: 'Footer Second'
-description: 'Site information links'
-locked: false

--- a/config/install/system.menu.footer-second.yml
+++ b/config/install/system.menu.footer-second.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: footer-second
+label: 'Footer Second'
+description: 'Site information links'
+locked: false

--- a/config/install/uiowa_footer.settings.yml
+++ b/config/install/uiowa_footer.settings.yml
@@ -3,9 +3,9 @@ lockup:
   fid: {  }
   alt: ''
   url: ''
-social_media_menu: social
-custom_menu: footer
-custom_menu_2: footer-second
+social_media_menu: none
+custom_menu: none
+custom_menu_2: none
 additional_info:
   title: ''
   content:

--- a/config/install/uiowa_footer.settings.yml
+++ b/config/install/uiowa_footer.settings.yml
@@ -5,7 +5,7 @@ lockup:
   url: ''
 social_media_menu: social
 custom_menu: footer
-custom_menu_2: none
+custom_menu_2: footer-second
 additional_info:
   title: ''
   content:

--- a/config/install/uiowa_footer.settings.yml
+++ b/config/install/uiowa_footer.settings.yml
@@ -5,6 +5,7 @@ lockup:
   url: ''
 social_media_menu: social
 custom_menu: footer
+custom_menu_2: none
 additional_info:
   title: ''
   content:

--- a/css/uiowa-footer--default.css
+++ b/css/uiowa-footer--default.css
@@ -29,14 +29,6 @@
   color: #999999;
 }
 
-.block--custom-menu .menu {
-  column-count: 2;
-}
-.block--custom-menu .menu li {
-  -webkit-column-break-inside: avoid;
-  page-break-inside: avoid;
-  break-inside: avoid;
-}
 .block--custom-menu .menu a {
   color: #ffcd00;
 }

--- a/templates/uiowa-footer.html.twig
+++ b/templates/uiowa-footer.html.twig
@@ -2,7 +2,7 @@
 <div class="container-fluid">
   <div class="row uiowa-footer--{{ variant }}">
     {%  if lockup or additional_info_content or social_media_links %}
-      <div class="col-md-6 col-left">
+      <div class="col-md-8 col-left">
         {% if lockup %}
           <div class="block block--lockup">
             {% if lockup_url %}
@@ -13,7 +13,7 @@
           </div>
         {% endif %}
         {% if additional_info_content or social_media_menu %}
-          <div class="col-md-10 col-md-push-3">
+          <div class="col-md-10 col-md-push-2">
             {% if additional_info_content %}
               <div class="block block--additional-info">
                 {% if additional_info_title %}
@@ -39,12 +39,24 @@
       </div>
     {% endif %}
     {% if custom_menu and custom_menu_links %}
-      <div class="col-md-6 col-right">
+      <div class="col-sm-6 col-md-2 col-left">
         <div class="block block--custom-menu">
           <h2 id="custom-menu-title" class="block-title visually-hidden">{{ custom_menu_title }}</h2>
           <div class="block-content">
             <nav role="navigation" aria-labelledby="custom-menu-title">
               {{ custom_menu_links }}
+            </nav>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    {% if custom_menu_2 and custom_menu_2_links %}
+      <div class="col-sm-6 col-md-2 col-right">
+        <div class="block block--custom-menu">
+          <h2 id="custom-menu-2-title" class="block-title visually-hidden">{{ custom_menu_2_title }}</h2>
+          <div class="block-content">
+            <nav role="navigation" aria-labelledby="custom-menu-2-title">
+              {{ custom_menu_2_links }}
             </nav>
           </div>
         </div>

--- a/templates/uiowa-footer.html.twig
+++ b/templates/uiowa-footer.html.twig
@@ -1,7 +1,7 @@
 <footer>
 <div class="container-fluid">
   <div class="row uiowa-footer--{{ variant }}">
-    {%  if lockup or additional_info_content or social_media_links %}
+    {%  if lockup or additional_info_content or social_media_menu_links %}
       <div class="col-md-8 col-left">
         {% if lockup %}
           <div class="block block--lockup">

--- a/uiowa_footer.info.yml
+++ b/uiowa_footer.info.yml
@@ -3,3 +3,7 @@ description: 'Configuration and block implementation for common footer.'
 type: module
 core: 8.x
 package: University of Iowa
+dependencies:
+  - drupal:filter
+  - drupal:image
+  - drupal:menu

--- a/uiowa_footer.info.yml
+++ b/uiowa_footer.info.yml
@@ -6,4 +6,4 @@ package: University of Iowa
 dependencies:
   - drupal:filter
   - drupal:image
-  - drupal:menu
+  - drupal:system

--- a/uiowa_footer.module
+++ b/uiowa_footer.module
@@ -85,21 +85,26 @@ function uiowa_footer_form_system_site_information_settings_alter(&$form, FormSt
   // Menus.
   $menus = ['none' => 'None'];
   $menus = array_merge($menus, menu_ui_get_menus());
-  $form['uiowa_footer']['uiowa_footer_social_media_menu'] = [
+  $form['uiowa_footer']['uiowa_footer_menus'] = [
+    '#type' => 'details',
+    '#title' => t('Links'),
+    '#open' => TRUE,
+  ];
+  $form['uiowa_footer']['uiowa_footer_menus']['uiowa_footer_social_media_menu'] = [
     '#type' => 'select',
     '#title' => t('Social Media Menu'),
     '#description' => t('The menu used for social media links.'),
     '#options' => $menus,
     '#default_value' => $config->get('social_media_menu'),
   ];
-  $form['uiowa_footer']['uiowa_footer_custom_menu'] = [
+  $form['uiowa_footer']['uiowa_footer_menus']['uiowa_footer_custom_menu'] = [
     '#type' => 'select',
     '#title' => t('Custom Links Menu'),
     '#description' => t('The menu used for custom footer links.'),
     '#options' => $menus,
     '#default_value' => $config->get('custom_menu'),
   ];
-  $form['uiowa_footer']['uiowa_footer_custom_menu_2'] = [
+  $form['uiowa_footer']['uiowa_footer_menus']['uiowa_footer_custom_menu_2'] = [
     '#type' => 'select',
     '#title' => t('Custom Links Menu 2'),
     '#description' => t('Choose the menu for custom footer links.'),

--- a/uiowa_footer.module
+++ b/uiowa_footer.module
@@ -90,7 +90,6 @@ function uiowa_footer_form_system_site_information_settings_alter(&$form, FormSt
     '#title' => t('Social Media Menu'),
     '#description' => t('The menu used for social media links.'),
     '#options' => $menus,
-    '#disabled' => TRUE,
     '#default_value' => $config->get('social_media_menu'),
   ];
   $form['uiowa_footer']['uiowa_footer_custom_menu'] = [
@@ -98,7 +97,6 @@ function uiowa_footer_form_system_site_information_settings_alter(&$form, FormSt
     '#title' => t('Custom Links Menu'),
     '#description' => t('The menu used for custom footer links.'),
     '#options' => $menus,
-    '#disabled' => TRUE,
     '#default_value' => $config->get('custom_menu'),
   ];
   $form['uiowa_footer']['uiowa_footer_custom_menu_2'] = [
@@ -106,7 +104,6 @@ function uiowa_footer_form_system_site_information_settings_alter(&$form, FormSt
     '#title' => t('Custom Links Menu 2'),
     '#description' => t('Choose the menu for custom footer links.'),
     '#options' => $menus,
-    '#disabled' => TRUE,
     '#default_value' => $config->get('custom_menu_2'),
   ];
   // Additional Information.

--- a/uiowa_footer.module
+++ b/uiowa_footer.module
@@ -101,6 +101,13 @@ function uiowa_footer_form_system_site_information_settings_alter(&$form, FormSt
     '#disabled' => TRUE,
     '#default_value' => $config->get('custom_menu'),
   ];
+  $form['uiowa_footer']['uiowa_footer_custom_menu_2'] = [
+    '#type' => 'select',
+    '#title' => t('Custom Links Menu 2'),
+    '#description' => t('Choose the menu for custom footer links.'),
+    '#options' => $menus,
+    '#default_value' => $config->get('custom_menu_2'),
+  ];
   // Additional Information.
   $form['uiowa_footer']['uiowa_footer_additional_info'] = [
     '#type' => 'details',
@@ -136,6 +143,7 @@ function uiowa_footer_submit($form, FormStateInterface $form_state) {
     ->set('lockup.url', $form_state->getValue('uiowa_footer_lockup_url'))
     ->set('social_media_menu', $form_state->getValue('uiowa_footer_social_media_menu'))
     ->set('custom_menu', $form_state->getValue('uiowa_footer_custom_menu'))
+    ->set('custom_menu_2', $form_state->getValue('uiowa_footer_custom_menu_2'))
     ->set('additional_info.title', $form_state->getValue('uiowa_footer_additional_info_title'))
     ->set('additional_info.content', $form_state->getValue('uiowa_footer_additional_info_content'))
     ->save();
@@ -159,6 +167,7 @@ function uiowa_footer_theme($existing, $type, $theme, $path) {
         'lockup_url' => $uiowa_footer_config->get('lockup.url'),
         'social_media_menu' => $uiowa_footer_config->get('social_media_menu'),
         'custom_menu' => $uiowa_footer_config->get('custom_menu'),
+        'custom_menu_2' => $uiowa_footer_config->get('custom_menu_2'),
         'additional_info_title' => $uiowa_footer_config->get('additional_info.title'),
         'additional_info_content' => check_markup($uiowa_footer_config->get('additional_info.content.value'), $uiowa_footer_config->get('additional_info.content.format')),
       ],
@@ -208,6 +217,14 @@ function template_preprocess_uiowa_footer(&$variables) {
   if ($menu = Menu::load($custom_menu)) {
     $variables['custom_menu_title'] = $menu->label();
     $variables['custom_menu_links'] = uiowa_footer_generate_menu_markup($custom_menu);
+  }
+
+  // Generate custom menu 2 markup.
+  $custom_menu_2 = $variables['custom_menu_2'];
+  if (!empty($custom_menu_2) && $custom_menu_2 != 'none') {
+    $menu = Menu::load($custom_menu_2);
+    $variables['custom_menu_2_title'] = $menu->label();
+    $variables['custom_menu_2_links'] = uiowa_footer_generate_menu_markup($custom_menu_2);
   }
 }
 

--- a/uiowa_footer.module
+++ b/uiowa_footer.module
@@ -106,6 +106,7 @@ function uiowa_footer_form_system_site_information_settings_alter(&$form, FormSt
     '#title' => t('Custom Links Menu 2'),
     '#description' => t('Choose the menu for custom footer links.'),
     '#options' => $menus,
+    '#disabled' => TRUE,
     '#default_value' => $config->get('custom_menu_2'),
   ];
   // Additional Information.


### PR DESCRIPTION
This PR removes the footer-second menu, which has been moved into Rusty in PR #232.

This resolves #5 and should be released at the same time as (rusty PR #232](https://github.com/uiowa/rusty/pull/232).